### PR TITLE
Improve error handling for missing mdbtools

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ On Debian/Ubuntu systems `mdbtools` can be installed via `apt`:
 sudo apt-get install mdbtools
 ```
 
+On Windows you will need to install a compatible build of `mdbtools` and
+ensure the commands `mdb-tables` and `mdb-export` are available on your
+`PATH`. One approach is to use the Windows Subsystem for Linux (WSL) and
+install `mdbtools` inside the Linux environment.
+
 ## Running
 
 Start the server with:

--- a/server.py
+++ b/server.py
@@ -68,6 +68,11 @@ def upload_file():
                         'table': first,
                         'data': '\n'.join(data.splitlines()[:5])
                     }
+            except FileNotFoundError:
+                preview = {
+                    'table': 'Error',
+                    'data': 'mdbtools utilities not found. Please install mdbtools and ensure it is in your PATH.'
+                }
             finally:
                 os.remove(mdb_path)
     return render_template_string(HTML_TEMPLATE, tables=tables, preview=preview)


### PR DESCRIPTION
## Summary
- catch `FileNotFoundError` when `mdb-tables`/`mdb-export` are missing
- update README with instructions for installing `mdbtools` on Windows

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68779f7a74b883278022022e04c3e36a