### PR TITLE
Add script to export instrument data

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,18 @@ python server.py
 
 Then open your browser to [http://localhost:5000](http://localhost:5000)
 and upload an `.mdb` file to view its tables.
+
+## Exporting Instrument Data
+
+The `export_instruments.py` script allows exporting selected columns from the
+`Instruments` table of an MDB file. It filters rows where the `Type` column is
+`IO` and writes the columns `Tag`, `FullDescription`, `EGULow`, `EGUHigh`,
+`RawLow`, and `RawHigh` to a CSV file.
+
+Usage:
+
+```bash
+python export_instruments.py path/to/database.mdb
+```
+
+After running, the script prompts for the destination path of the CSV file.

--- a/export_instruments.py
+++ b/export_instruments.py
@@ -1,0 +1,54 @@
+import csv
+import os
+import sys
+
+import pyodbc
+
+
+def main():
+    if len(sys.argv) < 2:
+        print('Usage: python export_instruments.py <path_to_mdb>')
+        return
+
+    mdb_path = sys.argv[1]
+    if not os.path.exists(mdb_path):
+        print(f'MDB file not found: {mdb_path}')
+        return
+
+    conn_str = (
+        r'DRIVER={Microsoft Access Driver (*.mdb, *.accdb)};'
+        f'DBQ={mdb_path};'
+    )
+    try:
+        conn = pyodbc.connect(conn_str, autocommit=True)
+        cursor = conn.cursor()
+        query = (
+            "SELECT Tag, FullDescription, EGULow, EGUHigh, RawLow, RawHigh "
+            "FROM Instruments WHERE Type='IO'"
+        )
+        cursor.execute(query)
+        rows = cursor.fetchall()
+    except pyodbc.Error as e:
+        print(f'Error accessing MDB file: {e}')
+        return
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    output_path = input('Enter path to save CSV file: ').strip()
+    if not output_path:
+        print('No output path provided')
+        return
+
+    with open(output_path, 'w', newline='', encoding='utf-8') as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(['Tag', 'FullDescription', 'EGULow', 'EGUHigh', 'RawLow', 'RawHigh'])
+        for row in rows:
+            writer.writerow(row)
+    print(f'Exported {len(rows)} rows to {output_path}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `export_instruments.py` to export filtered columns from the `Instruments` table
- document usage in README

## Testing
- `python -m py_compile export_instruments.py server.py`

------
https://chatgpt.com/codex/tasks/task_e_687925f066dc8327a90051bd5d97fb5e