### PR TITLE
Add automatic instrument export on upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ python server.py
 ```
 
 Then open your browser to [http://localhost:5000](http://localhost:5000)
-and upload an `.mdb` file to view its tables.
+and upload an `.mdb` file to view its tables. After uploading the server also
+exports the `Instruments` table to a CSV file and presents a link to download
+the file.
 
 ## Exporting Instrument Data
 

--- a/server.py
+++ b/server.py
@@ -1,8 +1,44 @@
 import os
+import csv
 import tempfile
 
 import pyodbc
-from flask import Flask, request, render_template_string
+from flask import Flask, request, render_template_string, send_file, after_this_request
+
+
+def export_instruments_to_csv(mdb_path: str, csv_path: str) -> int:
+    """Export the Instruments table to a CSV file.
+
+    Only rows with Type='IO' are exported and the columns Tag,
+    FullDescription, EGULow, EGUHigh, RawLow and RawHigh are written.
+    Returns the number of rows exported.
+    """
+    conn_str = (
+        r'DRIVER={Microsoft Access Driver (*.mdb, *.accdb)};'
+        f'DBQ={mdb_path};'
+    )
+    conn = pyodbc.connect(conn_str, autocommit=True)
+    cursor = conn.cursor()
+    query = (
+        "SELECT Tag, FullDescription, EGULow, EGUHigh, RawLow, RawHigh "
+        "FROM Instruments WHERE Type='IO'"
+    )
+    cursor.execute(query)
+    rows = cursor.fetchall()
+    with open(csv_path, 'w', newline='', encoding='utf-8') as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow([
+            'Tag',
+            'FullDescription',
+            'EGULow',
+            'EGUHigh',
+            'RawLow',
+            'RawHigh',
+        ])
+        for row in rows:
+            writer.writerow(row)
+    conn.close()
+    return len(rows)
 
 HTML_TEMPLATE = """
 <!doctype html>
@@ -43,22 +79,29 @@ HTML_TEMPLATE = """
   <h2>Preview of {{ preview.table }}</h2>
   <pre>{{ preview.data }}</pre>
   {% endif %}
+  {% if csv_available %}
+  <p><a href="{{ url_for('download_csv') }}">Download Instruments CSV</a></p>
+  {% endif %}
 </body>
 </html>
 """
 
 app = Flask(__name__)
+app.config['CSV_PATH'] = None
 
 @app.route('/', methods=['GET', 'POST'])
 def upload_file():
     tables = []
     preview = None
+    csv_available = False
     if request.method == 'POST':
         file = request.files.get('file')
         if file and file.filename:
             with tempfile.NamedTemporaryFile(delete=False, suffix='.mdb') as tmp:
                 file.save(tmp.name)
                 mdb_path = tmp.name
+            with tempfile.NamedTemporaryFile(delete=False, suffix='.csv') as csv_tmp:
+                csv_path = csv_tmp.name
             conn_str = (
                 r'DRIVER={Microsoft Access Driver (*.mdb, *.accdb)};'
                 f'DBQ={mdb_path};'
@@ -80,14 +123,45 @@ def upload_file():
                         'data': '\n'.join(lines)
                     }
                 conn.close()
+                export_instruments_to_csv(mdb_path, csv_path)
+                app.config['CSV_PATH'] = csv_path
+                csv_available = True
             except pyodbc.Error as e:
                 preview = {
                     'table': 'Error',
                     'data': f'Error accessing MDB file: {e}'
                 }
+                try:
+                    os.remove(csv_path)
+                except Exception:
+                    pass
             finally:
                 os.remove(mdb_path)
-    return render_template_string(HTML_TEMPLATE, tables=tables, preview=preview)
+    return render_template_string(
+        HTML_TEMPLATE,
+        tables=tables,
+        preview=preview,
+        csv_available=csv_available,
+    )
+
+
+@app.route('/download_csv')
+def download_csv():
+    """Send the exported instruments CSV to the client."""
+    csv_path = app.config.get('CSV_PATH')
+    if not csv_path or not os.path.exists(csv_path):
+        return "No CSV file available", 404
+
+    @after_this_request
+    def remove_file(response):
+        try:
+            os.remove(csv_path)
+        except Exception:
+            pass
+        app.config['CSV_PATH'] = None
+        return response
+
+    return send_file(csv_path, as_attachment=True, download_name='instruments.csv')
 
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- export Instruments table to a temp CSV when an MDB is uploaded
- offer a download link for the CSV
- document the new behaviour in README

## Testing
- `python -m py_compile server.py export_instruments.py`

------
https://chatgpt.com/codex/tasks/task_e_6879293b27548327bfee67ff41df8948