### PR TITLE
Filter instruments export to ignore blank tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ the file.
 
 The `export_instruments.py` script allows exporting selected columns from the
 `Instruments` table of an MDB file. It filters rows where the `Type` column is
-`IO` and writes the columns `Tag`, `FullDescription`, `EGULow`, `EGUHigh`,
-`RawLow`, and `RawHigh` to a CSV file.
+`IO` **and where the `Tag` column is not blank**. The script writes the columns
+`Tag`, `FullDescription`, `EGULow`, `EGUHigh`, `RawLow`, and `RawHigh` to a CSV
+file.
 
 Usage:
 

--- a/export_instruments.py
+++ b/export_instruments.py
@@ -24,7 +24,7 @@ def main():
         cursor = conn.cursor()
         query = (
             "SELECT Tag, FullDescription, EGULow, EGUHigh, RawLow, RawHigh "
-            "FROM Instruments WHERE Type='IO'"
+            "FROM Instruments WHERE Type='IO' AND Tag <> '' AND Tag IS NOT NULL"
         )
         cursor.execute(query)
         rows = cursor.fetchall()

--- a/server.py
+++ b/server.py
@@ -21,7 +21,7 @@ def export_instruments_to_csv(mdb_path: str, csv_path: str) -> int:
     cursor = conn.cursor()
     query = (
         "SELECT Tag, FullDescription, EGULow, EGUHigh, RawLow, RawHigh "
-        "FROM Instruments WHERE Type='IO'"
+        "FROM Instruments WHERE Type='IO' AND Tag <> '' AND Tag IS NOT NULL"
     )
     cursor.execute(query)
     rows = cursor.fetchall()


### PR DESCRIPTION
## Summary
- export instruments while ignoring rows with empty `Tag`
- update README to mention `Tag` is required for exports

## Testing
- `python -m py_compile export_instruments.py server.py`


------
https://chatgpt.com/codex/tasks/task_e_68792bc748508327b13788f99817b4b8