### PR TITLE
Revise MDB upload feedback and CSV export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # MDB Web Server
 
 This repository contains a small Flask application that allows uploading a
-Microsoft Access `.mdb` file. After uploading, the server lists the tables
-found in the database and shows a preview of the first table using the
-Microsoft Access ODBC driver via `pyodbc`.
+Microsoft Access `.mdb` file. After uploading, the server exports the
+`Instruments` table to CSV and reports how many valid instruments were found
+using the Microsoft Access ODBC driver via `pyodbc`.
 
 ## Requirements
 
@@ -32,17 +32,20 @@ python server.py
 ```
 
 Then open your browser to [http://localhost:5000](http://localhost:5000)
-and upload an `.mdb` file to view its tables. After uploading the server also
-exports the `Instruments` table to a CSV file and presents a link to download
-the file.
+and upload an `.mdb` file. After uploading, the server exports the
+`Instruments` table to a CSV file and presents a link to download the file,
+reporting how many instruments were found.
 
 ## Exporting Instrument Data
 
 The `export_instruments.py` script allows exporting selected columns from the
 `Instruments` table of an MDB file. It filters rows where the `Type` column is
 `IO` **and where the `Tag` column is not blank**. The script writes the columns
-`Tag`, `FullDescription`, `EGULow`, `EGUHigh`, `RawLow`, and `RawHigh` to a CSV
-file.
+`Tag`, `FullDescription`, `EGULow`, `EGUHigh`, `RawLow`, `RawHigh` and several
+alarm/warning fields to a CSV file. The additional columns are `HALM_EN`,
+`HALM_SP`, `HALM_DB`, `HALM_DLY`, `HWARN_EN`, `HWARN_SP`, `HWARN_DB`,
+`HWARN_DLY`, `LALM_EN`, `LALM_SP`, `LALM_DB`, `LALM_DLY`, `LWARN_EN`,
+`LWARN_SP`, `LWARN_DB`, and `LWARN_DLY`.
 
 Usage:
 

--- a/export_instruments.py
+++ b/export_instruments.py
@@ -22,8 +22,16 @@ def main():
     try:
         conn = pyodbc.connect(conn_str, autocommit=True)
         cursor = conn.cursor()
+        table_names = [row.table_name for row in cursor.tables(tableType='TABLE')]
+        if 'Instruments' not in table_names:
+            print('Instruments table not found in the MDB file.')
+            return
         query = (
-            "SELECT Tag, FullDescription, EGULow, EGUHigh, RawLow, RawHigh "
+            "SELECT Tag, FullDescription, EGULow, EGUHigh, RawLow, RawHigh, "
+            "HALM_EN, HALM_SP, HALM_DB, HALM_DLY, "
+            "HWARN_EN, HWARN_SP, HWARN_DB, HWARN_DLY, "
+            "LALM_EN, LALM_SP, LALM_DB, LALM_DLY, "
+            "LWARN_EN, LWARN_SP, LWARN_DB, LWARN_DLY "
             "FROM Instruments WHERE Type='IO' AND Tag <> '' AND Tag IS NOT NULL"
         )
         cursor.execute(query)
@@ -44,7 +52,30 @@ def main():
 
     with open(output_path, 'w', newline='', encoding='utf-8') as csvfile:
         writer = csv.writer(csvfile)
-        writer.writerow(['Tag', 'FullDescription', 'EGULow', 'EGUHigh', 'RawLow', 'RawHigh'])
+        writer.writerow([
+            'Tag',
+            'FullDescription',
+            'EGULow',
+            'EGUHigh',
+            'RawLow',
+            'RawHigh',
+            'HALM_EN',
+            'HALM_SP',
+            'HALM_DB',
+            'HALM_DLY',
+            'HWARN_EN',
+            'HWARN_SP',
+            'HWARN_DB',
+            'HWARN_DLY',
+            'LALM_EN',
+            'LALM_SP',
+            'LALM_DB',
+            'LALM_DLY',
+            'LWARN_EN',
+            'LWARN_SP',
+            'LWARN_DB',
+            'LWARN_DLY',
+        ])
         for row in rows:
             writer.writerow(row)
     print(f'Exported {len(rows)} rows to {output_path}')


### PR DESCRIPTION
## Summary
- don't preview database contents when uploading
- show success message and exported row count instead
- report missing Instruments table errors
- include alarm/warning fields when exporting to CSV
- document new behavior in README

## Testing
- `python -m py_compile server.py export_instruments.py`

------
https://chatgpt.com/codex/tasks/task_e_6879321603c8832792390e01f682ad97